### PR TITLE
Adjust some codes to satisfy aot build and test out workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Marknotes FE Continuous Integration
+name: Build
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![codecov](https://codecov.io/gh/Christian-007/marknotes-fe/branch/master/graph/badge.svg)](https://codecov.io/gh/Christian-007/marknotes-fe)
 
+[![build](https://github.com/Christian-007/marknotes-fe/workflows/Build/badge.svg)](https://github.com/Christian-007/marknotes-fe/actions)
+
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 8.3.26.
 
 ## Development server

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,7 +16,7 @@ import {
 import { SidebarModule } from '@app/shared/components/sidebar/sidebar.module';
 
 import { NotesEffects } from '@app/shared/store/effects/notes.effects';
-import { reducers } from '@app/shared/store/reducers';
+import { reducers, REDUCERS_TOKEN } from '@app/shared/store/reducers';
 import { LocalStorageStrategy } from '@app/shared/services/storage-strategy/local-storage-strategy';
 import { OverlayContainerComponent } from '@app/shared/components/overlay-container/overlay-container.component';
 import { OverlayContainerModule } from '@app/shared/components/overlay-container/overlay-container.module';
@@ -33,7 +33,7 @@ import { ToolbarDialogModule } from './shared/components/toolbar-dialog/toolbar-
     TopbarModule,
     SidebarModule,
     OverlayContainerModule,
-    StoreModule.forRoot(reducers),
+    StoreModule.forRoot(REDUCERS_TOKEN),
     EffectsModule.forRoot([NotesEffects, NavigationsEffects]),
     StoreDevtoolsModule.instrument({}),
     MobileEditorNavModule,
@@ -46,6 +46,10 @@ import { ToolbarDialogModule } from './shared/components/toolbar-dialog/toolbar-
     customSanitizerProvider,
     LocalStorageStrategy,
     notesServiceProvider,
+    {
+      provide: REDUCERS_TOKEN,
+      useValue: reducers,
+    },
   ],
   bootstrap: [AppComponent, OverlayContainerComponent],
 })

--- a/src/app/pages/notes/notes.service.ts
+++ b/src/app/pages/notes/notes.service.ts
@@ -1,4 +1,3 @@
-import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Update } from '@ngrx/entity';
 
@@ -6,7 +5,6 @@ import { INote } from '@app/shared/models/markdown-state.model';
 import { StorageStrategy } from '@app/shared/services/storage-strategy/storage-strategy';
 import { EStorageStrategy } from '@app/shared/enums/strategy.enum';
 
-@Injectable()
 export class NotesService {
   private storageStrategy: StorageStrategy;
 

--- a/src/app/shared/components/card/card.component.html
+++ b/src/app/shared/components/card/card.component.html
@@ -3,10 +3,7 @@
     <div class="mr-auto d-flex align-items-center">
       NOTES
     </div>
-    <app-button
-      [buttonStyles]="buttonStyles"
-      (buttonClick)="onClickAddNote($event)"
-    >
+    <app-button [buttonStyles]="buttonStyles" (buttonClick)="onClickAddNote()">
       <i aria-hidden="true" class="material-icons md-18">add_circle_outline</i>
     </app-button>
   </div>

--- a/src/app/shared/components/topbar/topbar.component.html
+++ b/src/app/shared/components/topbar/topbar.component.html
@@ -12,7 +12,7 @@
     </app-button>
     <app-toggle-button
       [checked]="isPreview$ | async"
-      (buttonClick)="onClickPreview($event)"
+      (buttonClick)="onClickPreview()"
       [disabled]="(hasNotesInStorage$ | async) === false"
     >
       <i aria-hidden="true" class="material-icons md-18">visibility</i>

--- a/src/app/shared/store/reducers/index.ts
+++ b/src/app/shared/store/reducers/index.ts
@@ -1,3 +1,4 @@
+import { InjectionToken } from '@angular/core';
 import {
   createFeatureSelector,
   createSelector,
@@ -12,6 +13,10 @@ export interface ApplicationState {
   [fromNotes.notesFeatureKey]: fromNotes.NotesState;
   [fromNavigation.navigationFeatureKey]: fromNavigation.NavigationState;
 }
+
+export const REDUCERS_TOKEN = new InjectionToken<
+  ActionReducerMap<ApplicationState>
+>('Registered Reducers');
 
 export const reducers: ActionReducerMap<ApplicationState> = {
   [fromNotes.notesFeatureKey]: fromNotes.notesReducer,


### PR DESCRIPTION
This PR is created for attempting to solve errors that occurred when running `npm run build:prod` and also test out the new Github Actions Workflows setup.

### Changes
- Remove `$event` param on HTML
- Adjust workflows config to enable `node_modules` caching
- Add Build badge to README
- Register `REDUCERS_TOKEN`
- Remove `@Injectable()` decorator on `NotesService`